### PR TITLE
Add refresh token and redirects to login page when token expires

### DIFF
--- a/src/Components/AuthCallback/AuthCallbackComponent.jsx
+++ b/src/Components/AuthCallback/AuthCallbackComponent.jsx
@@ -15,8 +15,8 @@ const AuthCallback = () => {
             } else {
                 try {
                     let accessToken = await getAccessToken(clientId, code);
-                    if (!localStorage.getItem("accessToken")) {
-                        localStorage.setItem("accessToken", accessToken);
+                    if (!localStorage.getItem("access_token")) {
+                        localStorage.setItem("access_token", accessToken);
                     }
 
                     navigate("/home");

--- a/src/Components/LandingPage/LandingPageComponent.jsx
+++ b/src/Components/LandingPage/LandingPageComponent.jsx
@@ -6,17 +6,20 @@ import "./LandingPage.css"
 
 const LandingPage = () => {
     const navigate = useNavigate();
+    const accessToken = localStorage.getItem("access_token");
 
     useEffect(() => {
-        if (isUserAutheticated()) {
-            navigate("/home");
-        }
+        (async () => {
+            if (await isUserAutheticated()) {
+                navigate("/home");
+            }
+        })();
     }, [navigate]);
 
     return (
         <main className="landing-page">
             <h1 className="landing-page-title">Welcome to Pandemic Sound!</h1>
-            {!isUserAutheticated() &&
+            {!accessToken &&
                 <button onClick={() => redirectToAuthCodeFlow(clientId)}>Log in with Spotify</button>
             }
         </main>

--- a/src/Components/Layout/Outlet/Homepage/Homepage.jsx
+++ b/src/Components/Layout/Outlet/Homepage/Homepage.jsx
@@ -3,7 +3,7 @@ import useGetRequest from "../../../../Hooks/useGetRequest";
 import "./homepage.css";
 
 const Homepage = () => {
-  const accessToken = localStorage.getItem("accessToken");
+  const accessToken = localStorage.getItem("access_token");
   const { data: newReleases, error, isLoading } = useGetRequest(
     "https://api.spotify.com/v1/browse/new-releases?offset=0",
     accessToken

--- a/src/Components/Layout/Outlet/PlaylistPage/PlaylistPage.jsx
+++ b/src/Components/Layout/Outlet/PlaylistPage/PlaylistPage.jsx
@@ -9,7 +9,7 @@ import { usePlaylists } from "../../../../Hooks/PlaylistsProvider";
 const PlaylistDisplay = () => {
   const { playlistId } = useParams();
   const profile = useProfile();
-  const accessToken = localStorage.getItem("accessToken");
+  const accessToken = localStorage.getItem("access_token");
   const [tracks, setTracks] = useState([]);
   const [error, setError] = useState();
   const { playlists, fetchPlaylists } = usePlaylists();

--- a/src/Components/Layout/Outlet/SearchPage/SearchPageComponent.jsx
+++ b/src/Components/Layout/Outlet/SearchPage/SearchPageComponent.jsx
@@ -12,7 +12,7 @@ const SearchPage = () => {
   const [activeTrackId, setActiveTrackId] = useState(null);
   const [filter, setFilter] = useState("all");
   const navigate = useNavigate();
-  const accessToken = localStorage.getItem("accessToken");
+  const accessToken = localStorage.getItem("access_token");
   const profile = useProfile();
 
   const params = new URLSearchParams(window.location.search);

--- a/src/Components/Layout/Outlet/SongPage/SongPage.jsx
+++ b/src/Components/Layout/Outlet/SongPage/SongPage.jsx
@@ -9,7 +9,7 @@ import { usePlaylists } from "../../../../Hooks/PlaylistsProvider";
 import "./songPage.css";
 
 const Song = () => {
-  const [accessToken] = useState(localStorage.getItem("accessToken"));
+  const [accessToken] = useState(localStorage.getItem("access_token"));
   const profile = useProfile();
   const [activeTrackId, setActiveTrackId] = useState(null);
   const [embedUrl, setEmbedUrl] = useState();

--- a/src/Hooks/PlaylistsProvider.jsx
+++ b/src/Hooks/PlaylistsProvider.jsx
@@ -9,7 +9,7 @@ export function usePlaylists() {
 function PlaylistsProvider({ children }) {
     const [playlists, setPlaylists] = useState([]);
     const profile = useProfile();
-    const accessToken = localStorage.getItem("accessToken");
+    const accessToken = localStorage.getItem("access_token");
 
     const fetchPlaylists = useCallback(async function() {
         if (!profile || !accessToken) {

--- a/src/Hooks/useDeleteRequest.jsx
+++ b/src/Hooks/useDeleteRequest.jsx
@@ -8,7 +8,7 @@ const useDeleteRequest = () => {
   const sendDeleteRequest = async (url, data) => {
     setIsLoading(true);
     setError(null);
-    const accessToken = localStorage.getItem("accessToken");
+    const accessToken = localStorage.getItem("access_token");
 
     try {
       const response = await fetch(url, {

--- a/src/Hooks/usePostRequest.jsx
+++ b/src/Hooks/usePostRequest.jsx
@@ -8,7 +8,7 @@ const usePostRequest = () => {
         setIsLoading(true);
         setError(null);
         
-        const token = localStorage.getItem("accessToken");
+        const token = localStorage.getItem("access_token");
         if (!token) {
             setError("No access token found");
             setIsLoading(false);

--- a/src/Hooks/usePutRequest.jsx
+++ b/src/Hooks/usePutRequest.jsx
@@ -7,7 +7,7 @@ const usePutRequest = () => {
   const sendPutRequest = async (url, bodyData) => {
     setIsLoading(true);
     setError(null);
-    const accessToken = localStorage.getItem("accessToken");
+    const accessToken = localStorage.getItem("access_token");
 
     if (!accessToken) {
       setError("No access token found");


### PR DESCRIPTION
Before, when the token was expired, it was needed to clean the local storage and re login in order to get a new valid access token.
These changes will refresh the token when access toke expires or will force to login again if both tokens (access_token and refresh_token) get expired.
